### PR TITLE
hotdogb: Remove 64-bit audio HAL prebuilt

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -13,7 +13,6 @@ odm/etc/acdbdata/Speaker_cal.acdb
 
 # Audio
 vendor/lib/hw/audio.primary.msmnile.so
-vendor/lib64/hw/audio.primary.msmnile.so
 
 # Camera
 odm/etc/camera/vidhance_calibration


### PR DESCRIPTION
It's unused.

Change-Id: Id2e784b89b77d72621a2ca64a601605f89d7f842